### PR TITLE
[DNM] optimization for shuffle read stage

### DIFF
--- a/src/main/scala/org/apache/spark/shuffle/compat/spark_2_4/UcxShuffleReader.scala
+++ b/src/main/scala/org/apache/spark/shuffle/compat/spark_2_4/UcxShuffleReader.scala
@@ -50,36 +50,8 @@ class UcxShuffleReader[K, C](handle: BaseShuffleHandle[K, _, C],
         SparkEnv.get.conf.get(config.MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM),
         SparkEnv.get.conf.getBoolean("spark.shuffle.detectCorrupt", true))
 
-      // Ucx shuffle logic
-      // Java reflection to get access to private results queue
-      val queueField = wrappedStreams.getClass.getDeclaredField(
-        "org$apache$spark$storage$ShuffleBlockFetcherIterator$$results")
-      queueField.setAccessible(true)
-      val resultQueue = queueField.get(wrappedStreams).asInstanceOf[LinkedBlockingQueue[_]]
-
-      // Do progress if queue is empty before calling next on ShuffleIterator
-      val ucxWrappedStream = new Iterator[(BlockId, InputStream)] {
-        override def next(): (BlockId, InputStream) = {
-          val startTime = System.currentTimeMillis()
-          while (resultQueue.isEmpty) {
-            transport.progress()
-          }
-          shuffleMetrics.incFetchWaitTime(System.currentTimeMillis() - startTime)
-          wrappedStreams.next()
-        }
-
-        override def hasNext: Boolean = {
-          val result = wrappedStreams.hasNext
-          if (!result) {
-            shuffleClient.close()
-          }
-          result
-        }
-      }
-      // End of ucx shuffle logic
-
       val serializerInstance = dep.serializer.newInstance()
-      val recordIter = ucxWrappedStream.flatMap { case (blockId, wrappedStream) =>
+      val recordIter = wrappedStreams.flatMap { case (blockId, wrappedStream) =>
         // Note: the asKeyValueIterator below wraps a key/value iterator inside of a
         // NextIterator. The NextIterator makes sure that close() is called on the
         // underlying InputStream when all records have been read.

--- a/src/main/scala/org/apache/spark/shuffle/compat/spark_3_0/UcxShuffleClient.scala
+++ b/src/main/scala/org/apache/spark/shuffle/compat/spark_3_0/UcxShuffleClient.scala
@@ -27,10 +27,7 @@ class UcxShuffleClient(val transport: UcxShuffleTransport, mapId2PartitionId: Ma
 
     val ucxBlockIds = Array.ofDim[UcxShuffleBlockId](blockIds.length)
     val callbacks = Array.ofDim[OperationCallback](blockIds.length)
-    var send = 0
-    var receive = 0
     for (i <- blockIds.indices) {
-      send = send + 1
       val blockId = SparkBlockId.apply(blockIds(i)).asInstanceOf[SparkShuffleBlockId]
       ucxBlockIds(i) = UcxShuffleBlockId(blockId.shuffleId, mapId2PartitionId(blockId.mapId), blockId.reduceId)
       callbacks(i) = (result: OperationResult) => {
@@ -45,11 +42,7 @@ class UcxShuffleClient(val transport: UcxShuffleTransport, mapId2PartitionId: Ma
       }
       val resultBufferAllocator = (size: Long) => transport.hostBounceBufferMemoryPool.get(size)
       transport.fetchBlocksByBlockIds(execId.toLong, Array(ucxBlockIds(i)), resultBufferAllocator, 
-        Array(callbacks(i)), () => {receive = receive + 1})
-    }
-
-    while (send != receive) {
-      transport.progress()
+        Array(callbacks(i)), () => {})
     }
   }
 

--- a/src/main/scala/org/apache/spark/shuffle/compat/spark_3_0/UcxShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/compat/spark_3_0/UcxShuffleManager.scala
@@ -34,17 +34,17 @@ class UcxShuffleManager(override val conf: SparkConf, isDriver: Boolean)
     logDebug("LEO UcxShuffleManager getWriter")
     val env = SparkEnv.get
     handle match {
-      case unsafeShuffleHandle: SerializedShuffleHandle[K@unchecked, V@unchecked] =>
-        logDebug("LEO UcxShuffleManager getWriter unsafeShuffleHandle")
-        new UnsafeShuffleWriter(
-          env.blockManager,
-          context.taskMemoryManager(),
-          unsafeShuffleHandle,
-          mapId,
-          context,
-          env.conf,
-          metrics,
-          shuffleExecutorComponents)
+      // case unsafeShuffleHandle: SerializedShuffleHandle[K@unchecked, V@unchecked] =>
+      //   logDebug("LEO UcxShuffleManager getWriter unsafeShuffleHandle")
+      //   new UnsafeShuffleWriter(
+      //     env.blockManager,
+      //     context.taskMemoryManager(),
+      //     unsafeShuffleHandle,
+      //     mapId,
+      //     context,
+      //     env.conf,
+      //     metrics,
+      //     shuffleExecutorComponents)
       case other: BaseShuffleHandle[K@unchecked, V@unchecked, _] =>
         logDebug("LEO UcxShuffleManager getWriter other")
         new SortShuffleWriter(

--- a/src/main/scala/org/apache/spark/shuffle/compat/spark_3_0/UcxShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/compat/spark_3_0/UcxShuffleManager.scala
@@ -34,17 +34,17 @@ class UcxShuffleManager(override val conf: SparkConf, isDriver: Boolean)
     logDebug("LEO UcxShuffleManager getWriter")
     val env = SparkEnv.get
     handle match {
-      // case unsafeShuffleHandle: SerializedShuffleHandle[K@unchecked, V@unchecked] =>
-      //   logDebug("LEO UcxShuffleManager getWriter unsafeShuffleHandle")
-      //   new UnsafeShuffleWriter(
-      //     env.blockManager,
-      //     context.taskMemoryManager(),
-      //     unsafeShuffleHandle,
-      //     mapId,
-      //     context,
-      //     env.conf,
-      //     metrics,
-      //     shuffleExecutorComponents)
+      case unsafeShuffleHandle: SerializedShuffleHandle[K@unchecked, V@unchecked] =>
+        logDebug("LEO UcxShuffleManager getWriter unsafeShuffleHandle")
+        new UnsafeShuffleWriter(
+          env.blockManager,
+          context.taskMemoryManager(),
+          unsafeShuffleHandle,
+          mapId,
+          context,
+          env.conf,
+          metrics,
+          shuffleExecutorComponents)
       case other: BaseShuffleHandle[K@unchecked, V@unchecked, _] =>
         logDebug("LEO UcxShuffleManager getWriter other")
         new SortShuffleWriter(

--- a/src/main/scala/org/apache/spark/shuffle/compat/spark_3_0/UcxShuffleReader.scala
+++ b/src/main/scala/org/apache/spark/shuffle/compat/spark_3_0/UcxShuffleReader.scala
@@ -112,32 +112,10 @@ private[spark] class UcxShuffleReader[K, C](handle: BaseShuffleHandle[K, _, C],
     queueField.setAccessible(true)
     val resultQueue = queueField.get(shuffleIterator).asInstanceOf[LinkedBlockingQueue[_]]
 
-    // Do progress if queue is empty before calling next on ShuffleIterator
-    val ucxWrappedStream = new Iterator[(BlockId, InputStream)] {
-      override def next(): (BlockId, InputStream) = {
-        val startTime = System.nanoTime()
-        while (resultQueue.isEmpty) {
-          transport.progress()
-        }
-        val fetchWaitTime = System.nanoTime() - startTime
-        readMetrics.incFetchWaitTime(TimeUnit.NANOSECONDS.toMillis(fetchWaitTime))
-        wrappedStreams.next()
-      }
-
-      override def hasNext: Boolean = {
-        val result = wrappedStreams.hasNext
-        if (!result) {
-          shuffleClient.close()
-        }
-        result
-      }
-    }
-    // End of ucx shuffle logic
-
     val serializerInstance = dep.serializer.newInstance()
 
     // Create a key/value iterator for each stream
-    val recordIter = ucxWrappedStream.flatMap { case (blockId, wrappedStream) =>
+    val recordIter = wrappedStreams.flatMap { case (blockId, wrappedStream) =>
       // Note: the asKeyValueIterator below wraps a key/value iterator inside of a
       // NextIterator. The NextIterator makes sure that close() is called on the
       // underlying InputStream when all records have been read.

--- a/src/main/scala/org/apache/spark/shuffle/ucx/CommonUcxShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/ucx/CommonUcxShuffleManager.scala
@@ -14,6 +14,7 @@ import org.apache.spark.shuffle.ucx.rpc.UcxRpcMessages.{ExecutorAdded, Introduce
 import org.apache.spark.shuffle.ucx.utils.SerializableDirectBuffer
 import org.apache.spark.util.{RpcUtils, ThreadUtils}
 import org.apache.spark.{SecurityManager, SparkConf, SparkEnv}
+import org.openucx.jucx.NativeLibs
 
 /**
  * Common part for all spark versions for UcxShuffleManager logic
@@ -22,6 +23,11 @@ abstract class CommonUcxShuffleManager(val conf: SparkConf, isDriver: Boolean) e
   type ShuffleId = Int
   type MapId = Int
   type ReduceId = Long
+  
+  /* Load UCX/JUCX libraries as soon as possible to avoid collision with JVM when register malloc/mmap hook. */
+  if (!isDriver) {
+    NativeLibs.load();
+  }
 
   val ucxShuffleConf = new UcxShuffleConf(conf)
 

--- a/src/main/scala/org/apache/spark/shuffle/ucx/DpuShuffleExecutorComponents.scala
+++ b/src/main/scala/org/apache/spark/shuffle/ucx/DpuShuffleExecutorComponents.scala
@@ -46,7 +46,6 @@ class NvkvShuffleExecutorComponents(val sparkConf: SparkConf, getTransport: () =
     transport = getTransport()
     val resultBufferAllocator = (size: Long) => transport.hostBounceBufferMemoryPool.get(size)
     transport.initExecuter(blockManager.blockManagerId.executorId.toLong, resultBufferAllocator)
-    transport.progress()
   }
 
   override def createMapOutputWriter(shuffleId: Int, mapTaskId: Long, numPartitions: Int) = {

--- a/src/main/scala/org/apache/spark/shuffle/ucx/NvkvShuffleMapOutputWriter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/ucx/NvkvShuffleMapOutputWriter.scala
@@ -143,7 +143,6 @@ class NvkvShuffleMapOutputWriter(private val shuffleId: Int,
     val resultBufferAllocator = (size: Long) => ucxTransport.hostBounceBufferMemoryPool.get(size)
     ucxTransport.commitBlock(executerId, resultBufferAllocator, packMapperData)
     NvkvShuffleMapOutputWriter.log.debug("Writing shuffle index file for mapId " + mapId + " with lengths " + partitionLengths(0) + " " + partitionLengths(1))
-    ucxTransport.progress()
     partitionLengths
   }
 

--- a/src/main/scala/org/apache/spark/shuffle/ucx/ShuffleTransport.scala
+++ b/src/main/scala/org/apache/spark/shuffle/ucx/ShuffleTransport.scala
@@ -147,22 +147,4 @@ trait ShuffleTransport {
    * Note: this is a blocking call. On return it's safe to free blocks memory.
    */
   def unregister(blockId: BlockId): Unit
-
-  /**
-   * Batch version of [[ fetchBlocksByBlockIds ]].
-   */
-  def fetchBlocksByBlockIds(executorId: ExecutorId, blockIds: Seq[BlockId],
-                            resultBufferAllocator: BufferAllocator,
-                            callbacks: Seq[OperationCallback],
-                            amRecvStartCb: () => Unit): Seq[Request]
-
-  /**
-   * Progress outstanding operations. This routine is blocking (though may poll for event).
-   * It's required to call this routine within same thread that submitted [[ fetchBlocksByBlockIds ]].
-   *
-   * Return from this method guarantees that at least some operation was progressed.
-   * But not guaranteed that at least one [[ fetchBlocksByBlockIds ]] completed!
-   */
-  def progress(): Unit
-
 }

--- a/src/main/scala/org/apache/spark/shuffle/ucx/UcxWorkerWrapper.scala
+++ b/src/main/scala/org/apache/spark/shuffle/ucx/UcxWorkerWrapper.scala
@@ -272,6 +272,7 @@ case class UcxWorkerWrapper(worker: UcpWorker, transport: UcxShuffleTransport, i
   private def getConnection(executorId: transport.ExecutorId): UcpEndpoint = {
     // TODO: Skip connection if already connected to the DPU of this executor
 
+    // val startTime = System.currentTimeMillis()
     // while (!transport.executorAddresses.contains(executorId)) {
     //   if  (System.currentTimeMillis() - startTime >
     //     transport.ucxShuffleConf.getSparkConf.getTimeAsMs("spark.network.timeout", "100")) {
@@ -280,7 +281,6 @@ case class UcxWorkerWrapper(worker: UcpWorker, transport: UcxShuffleTransport, i
     // }
 
     connections.getOrElseUpdate(executorId,  {
-      val startTime = System.currentTimeMillis()
       val address = transport.executorAddresses(executorId)
       val desAddress = SerializationUtils.deserializeInetAddress(address)
 

--- a/src/main/scala/org/apache/spark/shuffle/ucx/UcxWorkerWrapper.scala
+++ b/src/main/scala/org/apache/spark/shuffle/ucx/UcxWorkerWrapper.scala
@@ -312,6 +312,7 @@ case class UcxWorkerWrapper(worker: UcpWorker, transport: UcxShuffleTransport, i
     })
   }
 
+  @inline
   def fetchBlocksByBlockIds(executorId: transport.ExecutorId, blockIds: Seq[BlockId],
                             resultBufferAllocator: transport.BufferAllocator,
                             callbacks: Seq[OperationCallback],
@@ -366,6 +367,7 @@ case class UcxWorkerWrapper(worker: UcpWorker, transport: UcxShuffleTransport, i
     // Seq(request)
   }
 
+  @inline
   def initExecuter(executorId: transport.ExecutorId, nvkvHandler: NvkvHandler,
                    resultBufferAllocator: transport.BufferAllocator,
                    callback: OperationCallback): Unit = {
@@ -413,6 +415,7 @@ case class UcxWorkerWrapper(worker: UcpWorker, transport: UcxShuffleTransport, i
     // request
   }
 
+  @inline
   def commitBlock(executorId: transport.ExecutorId, nvkvHandler: NvkvHandler,
                   resultBufferAllocator: transport.BufferAllocator, packMapperData: ByteBuffer,
                   callback: OperationCallback): Unit = {


### PR DESCRIPTION
Merge the optimization [PR#27](https://github.com/NVIDIA/sparkucx/pull/27) of sparkucx into the sparkdpu branch.

|id                | executor|   data | time/s |stage0/s|stage1/s|stage2/s|
|------------------|---------|--------|--------|--------|--------|--------|
| tcp              |        4|    38GB|   97.6 |   24.0 |   48.2 |   12.2 |
| sparkdpu - PR#   |        4|    38GB|  111.5 |   24.5 |   61.9 |   12.1 |
| sparkdpu - ofir  |        4|    38GB|  115.4 |   25.5 |   62.9 |   14.3 |